### PR TITLE
Remove unused Participant Package and Register hero buttons

### DIFF
--- a/app/components/imgHero.js
+++ b/app/components/imgHero.js
@@ -21,21 +21,23 @@ function imgHero({ img, header, subheader, cta1, cta2 }) {
         <div className="absolute inset-0 flex items-center flex-col justify-center gutter gap-[24px] h-full">
           <h1 className="w-full text-left">{header}</h1>
           <h2 className="text-primary-yellow text-left w-full">{subheader}</h2>
-          {cta2 == null ? (
-            <div className="flex flex-row gap-[24px] justify-center">
-              <Button size="large" style="primary" onClick={() => alert("This event is currently not available yet!")}>
-                {cta1}
-              </Button>
-            </div>
-          ) : (
-            <div className="flex flex-row gap-[24px] w-full justify-start">
-              <Button size="large" style="primary">
-                {cta1}
-              </Button>
-              <Button size="large" style="primary">
-                {cta2}
-              </Button>
-            </div>
+          {cta1 && (
+            cta2 == null ? (
+              <div className="flex flex-row gap-[24px] justify-center">
+                <Button size="large" style="primary" onClick={() => alert("This event is currently not available yet!")}>
+                  {cta1}
+                </Button>
+              </div>
+            ) : (
+              <div className="flex flex-row gap-[24px] w-full justify-start">
+                <Button size="large" style="primary">
+                  {cta1}
+                </Button>
+                <Button size="large" style="primary">
+                  {cta2}
+                </Button>
+              </div>
+            )
           )}
         </div>
       </section>

--- a/app/forwardVision/page.js
+++ b/app/forwardVision/page.js
@@ -14,8 +14,6 @@ function page() {
         subheader={
           "Showcase your entrepreneurial spirit and skills in our very own competition! Through a Dragon’s Den style pitch competition, teams will get the chance to build a business idea with the mentorship and guidance of industry professionals and experienced entrepreneurs."
         }
-        cta1={"Participant Package"}
-        cta2={"Register"}
         img={"/images/finalForwardVision.png"}
       />
 

--- a/app/ventureconnect/page.js
+++ b/app/ventureconnect/page.js
@@ -14,8 +14,6 @@ function page() {
         subheader={
           "Venture Connect is an afternoon workshop and fireside chat event that provides aspiring entrepreneurs with the opportunity to create meaningful connections with successful entrepreneurs."
         }
-        cta1={"Participant Package"}
-        cta2={"Register"}
         img={"/images/ventureConnect 2.png"}
       />
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Task

Remove two unused buttons from the Enactus marketing site.

## What changed

The Forward Vision and Venture Connect event detail pages each rendered two non-functional hero buttons — **Participant Package** and **Register** — with no links or click handlers. This matches the pattern on the Events listing page, where the Register CTA was already commented out.

- Removed `cta1` / `cta2` props from `app/forwardVision/page.js` and `app/ventureconnect/page.js`
- Updated `app/components/imgHero.js` to only render the button row when `cta1` is provided (avoids an empty button shell)

Functional CTAs such as **← Return to Events** on those pages are unchanged.

## Verification

- [x] `npm run build` passes (`next build`, Next.js 16.1.2)
- [x] Dev server visual check on `/forwardVision` and `/ventureconnect`:
  - Hero sections show title + subheader only (no Participant Package / Register buttons)
  - Return to Events button still present and linked

## Scope

- 3 files changed under `app/` only
- No dependency, config, or styling changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ac72e78-f79f-4319-8159-72cca4dfa024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ac72e78-f79f-4319-8159-72cca4dfa024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

