### PR TITLE
Caleb Jr CI: build guardrail + merge notify

### DIFF
--- a/.github/workflows/notify-merge.yml
+++ b/.github/workflows/notify-merge.yml
@@ -1,0 +1,15 @@
+name: Notify Caleb Jr on merge
+
+# When a PR is merged, ping Caleb Jr so it notifies the requester instantly
+# (no repo webhook needed — we lack admin to add one here). The endpoint is
+# idempotent and only notifies for PRs GitHub confirms are merged.
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsS -X POST https://enactus-caleb-jr.vercel.app/api/agent/settle

--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -1,0 +1,21 @@
+name: PR Guardrails
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    # Hard gate: the app must compile, or it could break the site.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
Two GitHub Actions, both free (public repo):

- **pr-guardrails.yml** — runs `next build` on every PR so a change can't break the build undetected (the hard gate the other repos have).
- **notify-merge.yml** — on PR merge, pings Caleb Jr so it notifies the requester instantly (we can't add a repo webhook here without admin; this is the admin-free equivalent).

Safe to merge — CI-only, no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)