### PR TITLE
Change site accent color from red to blue

### DIFF
--- a/app/components/button.js
+++ b/app/components/button.js
@@ -12,12 +12,12 @@ function Button({
   cta,
 }) {
   const baseClasses =
-    "items-center text-white hover:text-black hover:cursor-pointer ease-in-out duration-[300ms] focus:bg-red-600 w-fit font-dm-sans font-[600] text-[16px] leading-[1.4]";
+    "items-center text-white hover:text-black hover:cursor-pointer ease-in-out duration-[300ms] focus:bg-blue-600 w-fit font-dm-sans font-[600] text-[16px] leading-[1.4]";
 
   const variants = {
-    primary: "bg-[#C70D00] hover:bg-primary-red",
+    primary: "bg-secondary-red hover:bg-primary-red",
     disabled: "bg-gray-200 text-gray-400",
-    icon: "pr-[24px] bg-[#C70D00] hover:bg-primary-red",
+    icon: "pr-[24px] bg-secondary-red hover:bg-primary-red",
   };
 
   const sizes = {

--- a/app/components/imgCarousel.js
+++ b/app/components/imgCarousel.js
@@ -55,13 +55,13 @@ function ImgCarousel({ Carousel = [] }) {
                 <div className='absolute inset-0 flex flex-row justify-between items-center z-10'>
                     <button
                         onClick={goToPrevious}
-                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-[#C70D00] rounded-[16px]'
+                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-secondary-red rounded-[16px]'
                     >
                         <IoIosArrowBack className='text-4xl text-white' />
                     </button>
                     <button
                         onClick={goToNext}
-                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-[#C70D00] rounded-[16px] '
+                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-secondary-red rounded-[16px] '
                     >
                         <IoIosArrowForward className='text-4xl text-white' />
                     </button>

--- a/app/components/leadership.js
+++ b/app/components/leadership.js
@@ -9,7 +9,7 @@ function leadership({ img, name, position, linkedin, key }) {
     >
       <div className="relative w-full">
         <a href={linkedin} target="_blank">
-          <div className="w-full h-full bg-gradient-to-br from-[#DD7600] to-[#C80D00] absolute hover:opacity-[20%] opacity-[0] hover:cursor-pointer duration-300 transition-ease-in-out"></div>
+          <div className="w-full h-full bg-gradient-to-br from-[#0076DD] to-[#0047C7] absolute hover:opacity-[20%] opacity-[0] hover:cursor-pointer duration-300 transition-ease-in-out"></div>
         </a>
         <Image
           src={img}

--- a/app/components/navbar.js
+++ b/app/components/navbar.js
@@ -56,7 +56,7 @@ function Navbar() {
                                     <button
                                         key={item.label}
                                         className={` leading-none transition-all ${isActive
-                                            ? "text-[#ED8B6E] font-semibold"
+                                            ? "text-[#6EA8ED] font-semibold"
                                             : "text-white opacity-60 hover:opacity-100"
                                             }`}
                                         onClick={() => console.log("close nav")}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,8 +3,8 @@
 @import url("https://fonts.googleapis.com/css2?family=SF+Pro+Display:wght@400;500;600;700&display=swap"); */
 
 @theme {
-  --color-primary-red: #dc5939;
-  --color-secondary-red: #c70d00;
+  --color-primary-red: #3970dc;
+  --color-secondary-red: #0047c7;
   --color-primary-gray: #282828;
   --spacing-lg-gutter: 100px;
   --color-primary-yellow: #ffc220;

--- a/app/test/page.js
+++ b/app/test/page.js
@@ -120,7 +120,7 @@ function Page() {
             />
 
             <h1>H1, Hello</h1>
-            <h2 className='text-red-500'>H2, Hello</h2>
+            <h2 className='text-blue-500'>H2, Hello</h2>
             <h3>H3, Hello</h3>
             <h4>H4, Hello</h4>
             <h5>H5, Hello</h5>
@@ -133,7 +133,7 @@ function Page() {
                 body="We are Second Savour, where purpose meets palate. As a student-led social enterprise, our mission is to rescue rejected produce surplus and transform it into nutritious, long-lasting food items. We're not just about sustenance; we're on a mission to raise awareness about sustainable food consumption, sparking a collective reevaluation of our consumption habits.">
             </Label>
             <IconLabel
-                icon={<BoltIcon fontSize="large" color="#DC5939" />}
+                icon={<BoltIcon fontSize="large" color="#3970DC" />}
                 header="Pitching Streams"
                 subheader="asdjfisajkf"
                 body="Teams will develop a small enterprise focused on the theme of 'Climate Action'. On the event day, teams will pitch their ideas to a panel of investors to receive fictitious funding for the 'Scale-Up Session'.">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Task
Change the Enactus marketing site's red accent color to blue.

## Changes
Updated the site's primary/secondary accent tokens and replaced hardcoded red hex values with blue equivalents:

| Token / usage | Before | After |
|---|---|---|
| `--color-primary-red` | `#dc5939` | `#3970dc` |
| `--color-secondary-red` | `#c70d00` | `#0047c7` |
| Navbar active link | `#ED8B6E` | `#6EA8ED` |
| Leadership hover gradient | `#DD7600` → `#C80D00` | `#0076DD` → `#0047C7` |

**Files changed (6):**
- `app/globals.css` — design token values
- `app/components/button.js` — button backgrounds and focus state
- `app/components/imgCarousel.js` — carousel nav buttons
- `app/components/navbar.js` — active nav link color
- `app/components/leadership.js` — team card hover gradient
- `app/test/page.js` — test page color samples

Components using `text-primary-red`, `bg-primary-red`, or `var(--color-primary-red)` (homepage icons, competition headings, about page icons, etc.) inherit the new blue values automatically via the updated tokens.

## Verification
- `npm install` + `npm run build` — passed
- Dev server (`npm run dev`) — homepage loads (HTTP 200)
- Visual check — homepage renders with blue CTA button and blue accents

[Homepage with blue accent colors](https://cursor.com/agents/bc-84905c2c-0759-4dbb-aebe-5efc08ab2861/artifacts?path=%2Fworkspace%2F.artifacts%2Fhomepage-blue.png)

## Scope
- Frontend only (`app/`)
- No config, dependency, or lockfile changes
- 6 files, ~11 lines changed

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84905c2c-0759-4dbb-aebe-5efc08ab2861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84905c2c-0759-4dbb-aebe-5efc08ab2861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

