### PR TITLE
Change Enactus SFU website colors from red to blue

### DIFF
--- a/app/components/button.js
+++ b/app/components/button.js
@@ -12,12 +12,12 @@ function Button({
   cta,
 }) {
   const baseClasses =
-    "items-center text-white hover:text-black hover:cursor-pointer ease-in-out duration-[300ms] focus:bg-red-600 w-fit font-dm-sans font-[600] text-[16px] leading-[1.4]";
+    "items-center text-white hover:text-black hover:cursor-pointer ease-in-out duration-[300ms] focus:bg-blue-600 w-fit font-dm-sans font-[600] text-[16px] leading-[1.4]";
 
   const variants = {
-    primary: "bg-[#C70D00] hover:bg-primary-red",
+    primary: "bg-[#0047C7] hover:bg-primary-red",
     disabled: "bg-gray-200 text-gray-400",
-    icon: "pr-[24px] bg-[#C70D00] hover:bg-primary-red",
+    icon: "pr-[24px] bg-[#0047C7] hover:bg-primary-red",
   };
 
   const sizes = {

--- a/app/components/imgCarousel.js
+++ b/app/components/imgCarousel.js
@@ -55,13 +55,13 @@ function ImgCarousel({ Carousel = [] }) {
                 <div className='absolute inset-0 flex flex-row justify-between items-center z-10'>
                     <button
                         onClick={goToPrevious}
-                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-[#C70D00] rounded-[16px]'
+                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-[#0047C7] rounded-[16px]'
                     >
                         <IoIosArrowBack className='text-4xl text-white' />
                     </button>
                     <button
                         onClick={goToNext}
-                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-[#C70D00] rounded-[16px] '
+                        className='text-white mx-[24px]  hover:bg-primary-red hover:cursor-pointer ease-in-out duration-[300ms] px-[8px] py-[16px] bg-[#0047C7] rounded-[16px] '
                     >
                         <IoIosArrowForward className='text-4xl text-white' />
                     </button>

--- a/app/components/leadership.js
+++ b/app/components/leadership.js
@@ -9,7 +9,7 @@ function leadership({ img, name, position, linkedin, key }) {
     >
       <div className="relative w-full">
         <a href={linkedin} target="_blank">
-          <div className="w-full h-full bg-gradient-to-br from-[#DD7600] to-[#C80D00] absolute hover:opacity-[20%] opacity-[0] hover:cursor-pointer duration-300 transition-ease-in-out"></div>
+          <div className="w-full h-full bg-gradient-to-br from-[#0076DD] to-[#0047C7] absolute hover:opacity-[20%] opacity-[0] hover:cursor-pointer duration-300 transition-ease-in-out"></div>
         </a>
         <Image
           src={img}

--- a/app/components/navbar.js
+++ b/app/components/navbar.js
@@ -56,7 +56,7 @@ function Navbar() {
                                     <button
                                         key={item.label}
                                         className={` leading-none transition-all ${isActive
-                                            ? "text-[#ED8B6E] font-semibold"
+                                            ? "text-[#6E9BED] font-semibold"
                                             : "text-white opacity-60 hover:opacity-100"
                                             }`}
                                         onClick={() => console.log("close nav")}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,8 +3,8 @@
 @import url("https://fonts.googleapis.com/css2?family=SF+Pro+Display:wght@400;500;600;700&display=swap"); */
 
 @theme {
-  --color-primary-red: #dc5939;
-  --color-secondary-red: #c70d00;
+  --color-primary-red: #3970dc;
+  --color-secondary-red: #0047c7;
   --color-primary-gray: #282828;
   --spacing-lg-gutter: 100px;
   --color-primary-yellow: #ffc220;

--- a/app/test/page.js
+++ b/app/test/page.js
@@ -120,7 +120,7 @@ function Page() {
             />
 
             <h1>H1, Hello</h1>
-            <h2 className='text-red-500'>H2, Hello</h2>
+            <h2 className='text-blue-500'>H2, Hello</h2>
             <h3>H3, Hello</h3>
             <h4>H4, Hello</h4>
             <h5>H5, Hello</h5>
@@ -133,7 +133,7 @@ function Page() {
                 body="We are Second Savour, where purpose meets palate. As a student-led social enterprise, our mission is to rescue rejected produce surplus and transform it into nutritious, long-lasting food items. We're not just about sustenance; we're on a mission to raise awareness about sustainable food consumption, sparking a collective reevaluation of our consumption habits.">
             </Label>
             <IconLabel
-                icon={<BoltIcon fontSize="large" color="#DC5939" />}
+                icon={<BoltIcon fontSize="large" color="#3970DC" />}
                 header="Pitching Streams"
                 subheader="asdjfisajkf"
                 body="Teams will develop a small enterprise focused on the theme of 'Climate Action'. On the event day, teams will pitch their ideas to a panel of investors to receive fictitious funding for the 'Scale-Up Session'.">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Task

Change the Enactus SFU website colors from red to blue.

## Change

Updated the Tailwind `@theme` primary/secondary accent tokens in `app/globals.css` from red to blue, and replaced hardcoded red hex values in buttons, navbar active links, image carousel controls, and the leadership card hover gradient.

## Verified

Verified: `next build` passes. Did NOT run the app or a browser (no runtime env).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80a60781-590a-477f-a8e5-eb9d52101031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80a60781-590a-477f-a8e5-eb9d52101031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

