### PR TITLE
Add interactive joke-telling agent

### DIFF
--- a/app/api/jokes/route.js
+++ b/app/api/jokes/route.js
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import {
+  buildAgentReply,
+  getCategories,
+  getGreeting,
+  parseUserMessage,
+} from "../../lib/jokes";
+
+export async function GET() {
+  return NextResponse.json({
+    greeting: getGreeting(),
+    categories: getCategories(),
+  });
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const message = body.message ?? "";
+    const lastSetup = body.lastSetup ?? null;
+    const intent = parseUserMessage(message);
+    const reply = buildAgentReply(intent.intent, {
+      category: intent.category,
+      lastSetup,
+    });
+
+    return NextResponse.json(reply);
+  } catch {
+    return NextResponse.json(
+      { type: "text", content: "Oops! My joke circuits got tangled. Try again?" },
+      { status: 400 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -12,6 +12,19 @@
   --foreground: white;
   --font-family-sf: "SF Pro Display", sans-serif;
   --font-family-dm: "DM Sans", sans-serif;
+
+  --animate-fade-in: fade-in 0.3s ease-out;
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 @layer base {

--- a/app/jokes/page.js
+++ b/app/jokes/page.js
@@ -1,0 +1,183 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Header from "../components/header";
+
+function JokeBubble({ message }) {
+  const isAgent = message.role === "agent";
+
+  return (
+    <div
+      className={`flex ${isAgent ? "justify-start" : "justify-end"} animate-fade-in`}
+    >
+      <div
+        className={`max-w-[85%] md:max-w-[70%] rounded-[16px] px-[20px] py-[16px] ${
+          isAgent
+            ? "bg-primary-gray text-white"
+            : "bg-primary-yellow text-black"
+        }`}
+      >
+        {message.content && <p className="mb-0">{message.content}</p>}
+        {message.joke && (
+          <div className="flex flex-col gap-[8px] mt-[8px]">
+            <p className="font-semibold">{message.joke.setup}</p>
+            <p
+              className={`font-medium ${
+                isAgent ? "text-primary-yellow" : "text-secondary-red"
+              }`}
+            >
+              {message.joke.punchline}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Page() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [lastSetup, setLastSetup] = useState(null);
+  const chatEndRef = useRef(null);
+
+  useEffect(() => {
+    fetch("/api/jokes")
+      .then((res) => res.json())
+      .then((data) => {
+        setMessages([
+          {
+            id: "greeting",
+            role: "agent",
+            content: data.greeting,
+          },
+        ]);
+      });
+  }, []);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  async function sendMessage(text) {
+    const trimmed = text.trim();
+    if (!trimmed || loading) return;
+
+    const userMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content: trimmed,
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/jokes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: trimmed, lastSetup }),
+      });
+      const reply = await res.json();
+
+      if (reply.joke) {
+        setLastSetup(reply.joke.setup);
+      }
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `agent-${Date.now()}`,
+          role: "agent",
+          content: reply.content,
+          joke: reply.joke ?? null,
+        },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `error-${Date.now()}`,
+          role: "agent",
+          content: "My joke book fell off the shelf. Mind trying again?",
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    sendMessage(input);
+  }
+
+  return (
+    <div className="flex flex-col gap-[32px] md:gap-[48px] pb-[48px]">
+      <section className="padding pt-[32px]">
+        <Header
+          header="Joke Agent"
+          body="Your personal comedy companion. Ask for a joke, say hello, or just hit the button — laughter guaranteed*."
+        />
+        <p className="text-sm opacity-60">*Guarantee not legally binding.</p>
+      </section>
+
+      <section className="section-standard">
+        <div className="flex flex-col gap-[16px] bg-primary-gray rounded-[16px] p-[24px] min-h-[400px] max-h-[60vh] overflow-y-auto">
+          {messages.map((message) => (
+            <JokeBubble key={message.id} message={message} />
+          ))}
+          {loading && (
+            <div className="flex justify-start">
+              <div className="bg-primary-gray rounded-[16px] px-[20px] py-[16px] text-white opacity-70">
+                <p className="animate-pulse">Thinking of something funny...</p>
+              </div>
+            </div>
+          )}
+          <div ref={chatEndRef} />
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-[12px] mt-[16px]">
+          <button
+            type="button"
+            onClick={() => sendMessage("Tell me a joke!")}
+            disabled={loading}
+            className="px-[16px] py-[12px] rounded-[10px] bg-[#C70D00] hover:bg-primary-red text-white font-semibold transition-all duration-300 disabled:opacity-50"
+          >
+            Tell me a joke!
+          </button>
+          <button
+            type="button"
+            onClick={() => sendMessage("Another one!")}
+            disabled={loading}
+            className="px-[16px] py-[12px] rounded-[10px] border border-white/30 text-white hover:bg-white/10 font-semibold transition-all duration-300 disabled:opacity-50"
+          >
+            Another one!
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-[12px] mt-[16px]">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message... (try 'tell me a joke')"
+            disabled={loading}
+            className="flex-1 px-[16px] py-[12px] rounded-[10px] bg-black border border-white/20 text-white placeholder:text-white/40 focus:outline-none focus:border-primary-yellow"
+          />
+          <button
+            type="submit"
+            disabled={loading || !input.trim()}
+            className="px-[16px] py-[10px] rounded-[10px] bg-[#C70D00] hover:bg-primary-red text-white font-semibold transition-all duration-300 disabled:opacity-50"
+          >
+            Send
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+export default Page;

--- a/app/lib/jokes.js
+++ b/app/lib/jokes.js
@@ -1,0 +1,217 @@
+const jokes = [
+  {
+    setup: "Why did the entrepreneur bring a ladder to the pitch meeting?",
+    punchline: "They heard the investors were looking for high growth.",
+    category: "business",
+  },
+  {
+    setup: "What do you call a social enterprise that only works on weekends?",
+    punchline: "A side hustle with a mission statement.",
+    category: "business",
+  },
+  {
+    setup: "Why don't startups ever play hide and seek?",
+    punchline: "Because good luck hiding when your burn rate is public.",
+    category: "business",
+  },
+  {
+    setup: "How many Enactus members does it take to change a lightbulb?",
+    punchline: "One to change it, and twelve to turn it into a sustainable community initiative.",
+    category: "enactus",
+  },
+  {
+    setup: "What's an entrepreneur's favorite type of music?",
+    punchline: "Scaling heights.",
+    category: "business",
+  },
+  {
+    setup: "Why did the computer go to therapy?",
+    punchline: "It had too many bytes of emotional baggage.",
+    category: "tech",
+  },
+  {
+    setup: "What did the ocean say to the beach?",
+    punchline: "Nothing — it just waved.",
+    category: "general",
+  },
+  {
+    setup: "Why couldn't the bicycle stand up by itself?",
+    punchline: "It was two-tired.",
+    category: "general",
+  },
+  {
+    setup: "What do you call a fake noodle?",
+    punchline: "An impasta.",
+    category: "general",
+  },
+  {
+    setup: "Why did the scarecrow win an award?",
+    punchline: "He was outstanding in his field.",
+    category: "general",
+  },
+  {
+    setup: "What do you call a bear with no teeth?",
+    punchline: "A gummy bear.",
+    category: "general",
+  },
+  {
+    setup: "Why did the coffee file a police report?",
+    punchline: "It got mugged.",
+    category: "general",
+  },
+  {
+    setup: "What's the best thing about Switzerland?",
+    punchline: "I don't know, but the flag is a big plus.",
+    category: "general",
+  },
+  {
+    setup: "Why don't scientists trust atoms?",
+    punchline: "Because they make up everything.",
+    category: "science",
+  },
+  {
+    setup: "What did one wall say to the other?",
+    punchline: "I'll meet you at the corner.",
+    category: "general",
+  },
+  {
+    setup: "Why did the marketer get kicked off the trampoline?",
+    punchline: "They kept bouncing ideas without landing any.",
+    category: "business",
+  },
+  {
+    setup: "How does a project manager stay cool?",
+    punchline: "They stand next to the deliverables.",
+    category: "business",
+  },
+  {
+    setup: "What do you call a sustainability report that's actually fun to read?",
+    punchline: "Fiction.",
+    category: "enactus",
+  },
+];
+
+const greetings = [
+  "Hey there! I'm JokeBot — your officially unofficial comedy agent. Want a laugh? Just ask!",
+  "Welcome! I've got puns, one-liners, and the occasional entrepreneurial groaner. Hit me with a request!",
+  "Greetings, fellow human! I'm powered by pure dad-joke energy. Ready when you are.",
+];
+
+const responses = {
+  tellJoke: [
+    "Here's one for you:",
+    "Coming right up:",
+    "You asked, I deliver:",
+    "Brace yourself:",
+  ],
+  another: [
+    "Another one? I like your style.",
+    "Back for more? Respect.",
+    "You have excellent taste in comedy requests.",
+  ],
+  unknown: [
+    "I'm best at jokes! Try asking me to 'tell me a joke' or hit the button below.",
+    "Hmm, I'm a specialist — jokes are my thing. Want one?",
+    "I wish I could help with that, but my expertise is strictly comedic. Want a joke?",
+  ],
+  goodbye: [
+    "Catch you later! May your day be pun-derful.",
+    "Bye! Remember: laughter is the best ROI.",
+    "See you soon! Don't forget to smile between meetings.",
+  ],
+};
+
+function pickRandom(items) {
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+export function getGreeting() {
+  return pickRandom(greetings);
+}
+
+export function getRandomJoke(category = null, excludeSetup = null) {
+  let pool = jokes;
+
+  if (category && category !== "any") {
+    pool = jokes.filter((joke) => joke.category === category);
+  }
+
+  if (excludeSetup) {
+    const filtered = pool.filter((joke) => joke.setup !== excludeSetup);
+    if (filtered.length > 0) pool = filtered;
+  }
+
+  if (pool.length === 0) pool = jokes;
+
+  return pickRandom(pool);
+}
+
+export function getCategories() {
+  return [...new Set(jokes.map((joke) => joke.category))];
+}
+
+export function parseUserMessage(message) {
+  const text = message.toLowerCase().trim();
+
+  if (!text) {
+    return { intent: "empty" };
+  }
+
+  if (
+    text.includes("bye") ||
+    text.includes("goodbye") ||
+    text.includes("see you")
+  ) {
+    return { intent: "goodbye" };
+  }
+
+  if (
+    text.includes("another") ||
+    text.includes("more") ||
+    text.includes("again")
+  ) {
+    return { intent: "another" };
+  }
+
+  if (text.includes("joke") || text.includes("funny") || text.includes("laugh")) {
+    const categoryMatch = getCategories().find((cat) => text.includes(cat));
+    return { intent: "joke", category: categoryMatch || null };
+  }
+
+  if (text.includes("hello") || text.includes("hi") || text.includes("hey")) {
+    return { intent: "greeting" };
+  }
+
+  return { intent: "unknown" };
+}
+
+export function buildAgentReply(intent, options = {}) {
+  const { category = null, lastSetup = null } = options;
+
+  switch (intent) {
+    case "greeting":
+      return { type: "text", content: getGreeting() };
+    case "joke":
+    case "another": {
+      const intro =
+        intent === "another"
+          ? pickRandom(responses.another)
+          : pickRandom(responses.tellJoke);
+      const joke = getRandomJoke(category, lastSetup);
+      return {
+        type: "joke",
+        content: intro,
+        joke,
+      };
+    }
+    case "goodbye":
+      return { type: "text", content: pickRandom(responses.goodbye) };
+    case "empty":
+      return {
+        type: "text",
+        content: "Say something! Or just click the button — I don't judge.",
+      };
+    default:
+      return { type: "text", content: pickRandom(responses.unknown) };
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Joke Agent** — a chat-style comedy companion at `/jokes` that tells jokes on demand.

## What's included

- **`/jokes` page** — Interactive chat UI with message bubbles, quick-action buttons ("Tell me a joke!", "Another one!"), and a text input for natural requests
- **`/api/jokes` endpoint** — Handles joke requests with intent parsing (greetings, joke requests, follow-ups, goodbyes)
- **Curated joke library** — Mix of general humor plus Enactus/entrepreneurship-themed jokes

## How to try it

1. Run `npm run dev`
2. Visit `/jokes`
3. Click "Tell me a joke!" or type something like "tell me a joke"

## Notes

- Jokes are served from a local library (no external API dependency)
- Styling matches the existing Enactus SFU dark theme with yellow/red accents
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9acbc871-2141-4144-8fa9-cc60e8344f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9acbc871-2141-4144-8fa9-cc60e8344f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

