### PR TITLE
Embed the Luma events calendar on /events

### DIFF
--- a/app/components/connectCard.js
+++ b/app/components/connectCard.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+function connectCard({ icon, name, cta = "Events", ctaLink, target = "_blank" }) {
+  return (
+    <div className="flex flex-row items-center gap-[16px] w-full bg-primary-gray rounded-[16px] p-[12px] md:p-[16px]">
+      <div className="flex items-center justify-center shrink-0 w-[48px] h-[48px] rounded-[12px] bg-white/5 border border-white/10 text-primary-yellow">
+        {icon}
+      </div>
+
+      <h4 className="grow font-[600] leading-[1.5]">{name ?? "Service"}</h4>
+
+      <a href={ctaLink} target={target} rel="noopener noreferrer">
+        <button
+          type="button"
+          className="w-fit px-[16px] py-[10px] rounded-[10px] bg-white/10 hover:bg-white/20 hover:cursor-pointer text-white font-dm-sans font-[600] text-[16px] leading-[1.4] ease-in-out duration-[300ms]"
+        >
+          {cta}
+        </button>
+      </a>
+    </div>
+  );
+}
+
+export default connectCard;

--- a/app/events/page.js
+++ b/app/events/page.js
@@ -1,6 +1,8 @@
 import React from "react";
 import Header from "../components/header";
 import ImgLabel from "../components/imglabel";
+import ConnectCard from "../components/connectCard";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 
 function page() {
   return (
@@ -28,6 +30,32 @@ function page() {
           // cta2="Register"
           img="/images/VentureConnect.jpg"
         ></ImgLabel>
+      </div>
+
+      <div className="flex flex-col gap-[24px] w-full">
+        <div className="flex flex-col gap-[8px]">
+          <h2>Upcoming Events</h2>
+          <h3 className="opacity-60">
+            Follow our Luma calendar to see what&apos;s coming up and get
+            notified when registration opens.
+          </h3>
+        </div>
+
+        <iframe
+          src="https://luma.com/embed/calendar/cal-RsECMxK7cyQW34Y/events?lt=dark"
+          title="Enactus SFU events calendar"
+          className="w-full h-[450px] rounded-[4px] border border-[#bfcbda88]"
+          allowFullScreen
+          aria-hidden="false"
+          tabIndex={0}
+        ></iframe>
+
+        <ConnectCard
+          name="Luma"
+          cta="Events"
+          ctaLink="https://luma.com/enactussfu"
+          icon={<CalendarMonthIcon />}
+        ></ConnectCard>
       </div>
     </div>
   );


### PR DESCRIPTION
Adds the Luma calendar under the two event cards on `/events`, per the thread with Juliana.

### What's in here
- **New `connectCard` component** ([app/components/connectCard.js](app/components/connectCard.js)) — icon tile, service name, and a right-aligned pill CTA. Styled off the reference screenshot, but in the site's dark palette (`primary-gray` card, yellow icon, white/10 button) instead of the white original.
- **Luma embed on `/events`** — the calendar iframe (`?lt=dark`) below the event cards, full-width and 450px tall, followed by a `connectCard` for Luma whose **Events** button links out to the public calendar.

### Links used
- Embed: `https://luma.com/embed/calendar/cal-RsECMxK7cyQW34Y/events?lt=dark`
- Public calendar: `https://luma.com/enactussfu` — this is the canonical URL Luma reports for calendar `cal-RsECMxK7cyQW34Y` ("Org-wide Events"), so the CTA points at a stable vanity link rather than the raw calendar id.

### Verified
- `npm run build` passes.
- Rendered on the dev server: the embed loads real events (Forward Vision: Pitch Competition, Oct 25) and the card matches the surrounding dark UI. No new console errors — the only warning on the page is the pre-existing `Logo.svg` aspect-ratio one from the navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)