### PR TITLE
Make project name headers yellow on Projects page

### DIFF
--- a/app/components/imgbanner.js
+++ b/app/components/imgbanner.js
@@ -21,7 +21,7 @@ function imgbanner({ header, body, cta1, cta2, instagram, linkedin, img, pm1, pm
         <div className="flex flex-col gap-[16px] h-[100%] w-full ">
           <div className='flex flex-col md:flex-row gap-[32px] md:gap-[64px]'>
             <div className="flex flex-col gap-[16px] justify-between">
-              <h2>{header}</h2>
+              <h2 className="text-primary-yellow">{header}</h2>
               <h3>{body}</h3>
             </div>
             {(pm1 || pm2) && (

--- a/app/components/label.js
+++ b/app/components/label.js
@@ -4,7 +4,7 @@ function label({ header, subheader, body }) {
   return (
     <div className="bg-primary-gray p-[48px] flex flex-col md:flex-row rounded-sm gap-[48px]">
       <div className="flex flex-col gap-[8px] min-w-[20%]">
-        <h2 className="">{header}</h2>
+        <h2 className="text-primary-yellow">{header}</h2>
         <h3 className="text-primary-yellow flex flex-nowrap w-fit">
           {subheader}
         </h3>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Task

On the Projects page of the enactus website, make all the project name headers yellow.

## Change

Added the existing `text-primary-yellow` class to project name `<h2>` headers in `ImgBanner` (current projects) and `Label` (past projects). Both components are only used on `/projects`.

## Verified

Verified: `npm run build` passes. Did NOT run the app or a browser (no runtime env).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6beffda-bd87-4a97-aab9-c1d552598166?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6beffda-bd87-4a97-aab9-c1d552598166&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

