### PR TITLE
Center the header "Our Partners for Forward Vision" to the width of the screen on the "Our Partners" page.

### DIFF
--- a/app/sponsor/page.js
+++ b/app/sponsor/page.js
@@ -210,7 +210,7 @@ function page() {
       </div>
 
       <div>
-        <h1 className="mb-8">Our Partners for Forward Vision</h1>
+        <h1 className="mb-8 text-center">Our Partners for Forward Vision</h1>
 
         <div className="flex flex-wrap justify-center gap-[16px] md:gap-[20px]">
           {forwardVisionList.map((sponsor) => (


### PR DESCRIPTION
Closes #22

Center the "Our Partners for Forward Vision" header across the width of the page on the Our Partners page (`/sponsor`).

Added the repo's existing `text-center` class to that `<h1>` in `app/sponsor/page.js`. The heading already spans the full page container, so the text now centers across it — matching the `justify-center` partner logos directly beneath it. One line changed; nothing else touched.

Verified: `npm run build` (`next build`) passes. Did not run the app or view it in a browser.

Caleb Jr ticket: #8BE68F

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4RixqEfmHFAJhTEZFCnjF

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4RixqEfmHFAJhTEZFCnjF)_